### PR TITLE
Fix Event Queue

### DIFF
--- a/joy/CMakeLists.txt
+++ b/joy/CMakeLists.txt
@@ -56,15 +56,9 @@ else()
 
 
   file(DOWNLOAD
-<<<<<<< HEAD
       https://raw.githubusercontent.com/gabomdq/SDL_GameControllerDB/e84ccd2617a2c5c507e08a0b6221a7bc23d97695/gamecontrollerdb.txt
       ${PROJECT_SOURCE_DIR}/launch/gamecontrollerdb.txt
       EXPECTED_HASH SHA512=57ec9435015028d768bd7a2c2c841923bfda88c72cbf33d9c5aa0809ae10b1933c597c748a69414285cdd0a6e1488694c622b884eb2992a23c28025fae77b646
-=======
-      https://raw.githubusercontent.com/gabomdq/SDL_GameControllerDB/master/gamecontrollerdb.txt
-      ${PROJECT_SOURCE_DIR}/launch/gamecontrollerdb.txt
-      EXPECTED_HASH SHA512=226df49456270605ac388ee7cfe6edd60a51d60150031ca35ccc0ac1d4b88602afe6a4de1b10906cdeb39988653faa1e5275d6c517110ee139490fb3d501c43b
->>>>>>> 8d95beb... Add Support for 3rd party Mappings
       SHOW_PROGRESS
   )    
 

--- a/joy/CMakeLists.txt
+++ b/joy/CMakeLists.txt
@@ -56,9 +56,15 @@ else()
 
 
   file(DOWNLOAD
+<<<<<<< HEAD
       https://raw.githubusercontent.com/gabomdq/SDL_GameControllerDB/e84ccd2617a2c5c507e08a0b6221a7bc23d97695/gamecontrollerdb.txt
       ${PROJECT_SOURCE_DIR}/launch/gamecontrollerdb.txt
       EXPECTED_HASH SHA512=57ec9435015028d768bd7a2c2c841923bfda88c72cbf33d9c5aa0809ae10b1933c597c748a69414285cdd0a6e1488694c622b884eb2992a23c28025fae77b646
+=======
+      https://raw.githubusercontent.com/gabomdq/SDL_GameControllerDB/master/gamecontrollerdb.txt
+      ${PROJECT_SOURCE_DIR}/launch/gamecontrollerdb.txt
+      EXPECTED_HASH SHA512=226df49456270605ac388ee7cfe6edd60a51d60150031ca35ccc0ac1d4b88602afe6a4de1b10906cdeb39988653faa1e5275d6c517110ee139490fb3d501c43b
+>>>>>>> 8d95beb... Add Support for 3rd party Mappings
       SHOW_PROGRESS
   )    
 

--- a/joy/src/joy_node_win.cpp
+++ b/joy/src/joy_node_win.cpp
@@ -180,6 +180,7 @@ class Joystick
           {
             switch (e.type)
             {
+<<<<<<< HEAD
               case SDL_JOYAXISMOTION:
               {
                   //Motion on controller 0
@@ -200,6 +201,15 @@ class Joystick
                     }
 
                     joy_msg.axes[e.jaxis.axis] = value * scale;
+=======
+                //Motion on controller 0
+                if (e.jaxis.which == _gameControllerIndex)
+                {     
+                  float value = e.jaxis.value;                   
+                  if (value > _unscaled_deadzone)
+                  {
+                    value -= _unscaled_deadzone;
+>>>>>>> 0174569... uint -> float - handle negative values correctly
                   }
               }
               break;

--- a/joy/src/joy_node_win.cpp
+++ b/joy/src/joy_node_win.cpp
@@ -154,7 +154,6 @@ class Joystick
       if (_gameController == nullptr)
       {
         SDL_JoystickUpdate();
-
         int nJoysticks = SDL_NumJoysticks();
         for (int i = 0; i < nJoysticks; i++) 
         {
@@ -228,6 +227,7 @@ class Joystick
               break;
             }
           }
+
           joy_msg.header.stamp = ros::Time().now();
           _joystickPublisher.publish(joy_msg);
 

--- a/joy/src/joy_node_win.cpp
+++ b/joy/src/joy_node_win.cpp
@@ -180,7 +180,6 @@ class Joystick
           {
             switch (e.type)
             {
-<<<<<<< HEAD
               case SDL_JOYAXISMOTION:
               {
                   //Motion on controller 0
@@ -201,15 +200,6 @@ class Joystick
                     }
 
                     joy_msg.axes[e.jaxis.axis] = value * scale;
-=======
-                //Motion on controller 0
-                if (e.jaxis.which == _gameControllerIndex)
-                {     
-                  float value = e.jaxis.value;                   
-                  if (value > _unscaled_deadzone)
-                  {
-                    value -= _unscaled_deadzone;
->>>>>>> 0174569... uint -> float - handle negative values correctly
                   }
               }
               break;


### PR DESCRIPTION
The SDL2 Event poll maintains a queue of events. To process the events, you need to process the poll in a loop to drain the queue. This could cause a robot to be slow respond certain events.